### PR TITLE
Corregir header de task.service.ts

### DIFF
--- a/src/app/service/task.service.ts
+++ b/src/app/service/task.service.ts
@@ -6,7 +6,7 @@ import {TASKS} from '../mock-tasks';
 
 const httpOptions = {
   headers: new HttpHeaders({
-    'Content-Type':'aplication/json'
+    'Content-Type':'application/json'
   })
 }
 


### PR DESCRIPTION
Se corrigió aplication/json a application/json. Lo cual provocaba errores al modificar el reminder de una task y al crear una nueva task.